### PR TITLE
Replace 'TrueClass' with 'Boolean'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,11 +35,11 @@ Metrics/ModuleLength:
   Enabled: false
 
 # certificate_1 is an okay variable name
-Style/VariableNumber:
+Naming/VariableNumber:
   Enabled: false
 
 # This is used a lot across the fastlane code base for config files
-Style/MethodMissing:
+Style/MethodMissingSuper:
   Enabled: false
 
 #
@@ -201,7 +201,7 @@ Lint/ParenthesesAsGroupedExpression:
 
 # This would reject is_ in front of methods
 # We use `is_supported?` everywhere already
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 # We allow the $
@@ -221,7 +221,7 @@ AllCops:
     - './vendor/**/*'
 
 # They have not to be snake_case
-Style/FileName:
+Naming/FileName:
   Exclude:
     - '**/Dangerfile'
     - '**/Brewfile'

--- a/lib/fastlane/plugin/blackberry_mam/actions/blackberry_mam_network_check.rb
+++ b/lib/fastlane/plugin/blackberry_mam/actions/blackberry_mam_network_check.rb
@@ -85,7 +85,7 @@ module Fastlane
             key: :check_cloud_control,
             env_name: "FL_BLACKBERRY_MAM_NETWORK_CHECK_CLOUD_CONTROL",
             description: "API Token for BlackberryMamNetworkCheckAction",
-            type: TrueClass,
+            type: Boolean,
             default_value: true
           )
         ]

--- a/lib/fastlane/plugin/blackberry_mam/actions/update_info_plist_for_blackberry_mam_action.rb
+++ b/lib/fastlane/plugin/blackberry_mam/actions/update_info_plist_for_blackberry_mam_action.rb
@@ -118,10 +118,7 @@ module Fastlane
                                     env_name: "FL_UPDATE_INFO_PLIST_FOR_BLACKBERRY_MAM_BUILD_FOR_SIMULATOR",
                                     description: "True if the app should be built so that it simulates a connection to a Good Control Center server. Defaults to false",
                                     optional: true,
-                                    type: TrueClass,
-                                    verify_block: proc do |value|
-                                      UI.user_error!("Invalid value #{value}. It must either be true or false") unless [true, false].include?(value)
-                                    end,
+                                    type: Boolean,
                                     default_value: false) # the default value if the user didn't provide one
         ]
       end

--- a/spec/update_info_plist_for_blackberry_mam_action_spec.rb
+++ b/spec/update_info_plist_for_blackberry_mam_action_spec.rb
@@ -460,7 +460,7 @@ describe Fastlane do
 
           expect { Fastlane::FastFile.new.parse(update_info_plist_for_blackberry_mam_invalid_build_simulation_mode).runner.execute(:test) }.to(
             raise_error(FastlaneCore::Interface::FastlaneError) do |error|
-              expect(error.message).to match(/'build_simulation_mode' value must be a TrueClass! Found String instead./)
+              expect(error.message).to match(/'build_simulation_mode' value must be either `true` or `false`! Found String instead./)
             end
           )
         end


### PR DESCRIPTION
After upgrading Fastlane from `2.81.0` to `2.95.0`, we started getting an error when passing `false` for `build_simulation_mode` in `update_info_plist_for_blackberry_mam`.

```
You passed invalid parameters to 'update_info_plist_for_blackberry_mam'
'build_simulation_mode' value must be a TrueClass! Found FalseClass instead.
```

Doing some research into TrueClass reveals "_The global value true is the only instance of class TrueClass and represents a logically true value in boolean expressions_". [Source](https://ruby-doc.org/core-2.2.0/TrueClass.html)

I fixed this by replacing `TrueClass` with `Boolean` which will allows both true and false.

Additionally, RuboCop was reported a few configuration errors (shown below) which I resolved.
```
.rubocop.yml: Style/VariableNumber has the wrong namespace - should be Naming
.rubocop.yml: Style/PredicateName has the wrong namespace - should be Naming
.rubocop.yml: Style/FileName has the wrong namespace - should be Naming
Error: The `Style/MethodMissing` cop has been split into `Style/MethodMissingSuper` and `Style/MissingRespondToMissing`.
(obsolete configuration found in .rubocop.yml, please update it)
```